### PR TITLE
fix: update the activityID in LFGList

### DIFF
--- a/Modules/Misc/LFGList.lua
+++ b/Modules/Misc/LFGList.lua
@@ -278,8 +278,9 @@ function LL:UpdateEnumerate(Enumerate)
 		return
 	end
 
+	local activityID = result.activityIDs and result.activityIDs[1] or nil
 	local result = C_LFGList_GetSearchResultInfo(button.resultID)
-	local info = C_LFGList_GetActivityInfoTable(result.activityID)
+	local info = C_LFGList_GetActivityInfoTable(activityID)
 
 	if not result then
 		return


### PR DESCRIPTION
Blizzard change the way of retrieving the activityID
Fix the broken issue in LFGList