### PR TITLE
feat: add new 11.1.7 Hearthstone

### DIFF
--- a/Modules/Misc/GameBar.lua
+++ b/Modules/Misc/GameBar.lua
@@ -166,6 +166,8 @@ local hearthstoneAndToyIDList = {
 	221966, -- 蟲洞產生器：卡茲阿爾加
 	--Liberation of Undermine Drop
 	236687, -- 爆裂爐石
+	-- Overcharged Delves (11.1.7)
+	235016,
 }
 
 local hearthstonesAndToysData


### PR DESCRIPTION
The Redeployment Module Hearthstone toy was made available in patch 11.1.7.

Wowhead Link: https://www.wowhead.com/item=235016/redeployment-module