### PR TITLE
Add sound to quest objective progress

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,12 @@
   "Lua.workspace.library": [
     "~\\.vscode\\extensions\\ketho.wow-api-0.21.0\\Annotations\\Core",
     "~\\.vscode\\extensions\\ketho.wow-api-0.21.0\\Annotations\\FrameXML"
+  ],
+  "Lua.diagnostics.globals": [
+    "coroutine",
+    "RED_FONT_COLOR",
+    "QUEST_OBJECTIVE_COMPLETED_FONT_COLOR",
+    "YELLOW_FONT_COLOR",
+    "HIGHLIGHT_FONT_COLOR"
   ]
 }

--- a/Modules/Quest/Progress.lua
+++ b/Modules/Quest/Progress.lua
@@ -40,6 +40,7 @@ local QUEST_STATUS = {
 	COMPLETED = 2,
 	QUEST_UPDATE = 3,
 	SCENARIO_UPDATE = 4,
+	OBJECTIVE_UPDATE = 5,
 }
 
 local cachedQuests ---@type table<number, QuestProgressData>
@@ -376,6 +377,8 @@ function QP:PlaySoundEffect(status)
 		db = self.db.soundEffects.fullyComplete
 	elseif status == QUEST_STATUS.QUEST_UPDATE then
 		db = self.db.soundEffects.partialComplete
+	elseif status == QUEST_STATUS.OBJECTIVE_UPDATE then
+		db = self.db.soundEffects.objectiveProgress
 	end
 
 	if not db or not db.enable then
@@ -427,6 +430,7 @@ function QP:HandleQuestProgress(status, questData, objectiveData)
 			self:PlaySoundEffect(QUEST_STATUS.QUEST_UPDATE)
 		else
 			coloredContext.icon = ""
+			self:PlaySoundEffect(QUEST_STATUS.OBJECTIVE_UPDATE)
 		end
 	end
 

--- a/Options/Quest.lua
+++ b/Options/Quest.lua
@@ -1410,8 +1410,34 @@ options.progress = {
 						},
 					},
 				},
+				objectiveProgress = {
+					order = 4,
+					type = "group",
+					inline = true,
+					name = L["Objective Progress"],
+					disabled = function()
+						return not E.db.WT.quest.progress.soundEffects.enable
+					end,
+					args = {
+						enable = {
+							order = 1,
+							type = "toggle",
+							name = L["Enable"],
+						},
+						sound = {
+							order = 3,
+							type = "select",
+							dialogControl = "LSM30_Sound",
+							name = L["Sound"],
+							values = LSM:HashTable("sound"),
+							hidden = function()
+								return not E.db.WT.quest.progress.soundEffects.objectiveProgress.enable
+							end,
+						},
+					},
+				},
 				partialComplete = {
-					order = 3,
+					order = 4,
 					type = "group",
 					inline = true,
 					name = L["Partial Complete"],
@@ -1437,7 +1463,7 @@ options.progress = {
 					},
 				},
 				fullyComplete = {
-					order = 4,
+					order = 5,
 					type = "group",
 					inline = true,
 					name = L["Fully Complete"],

--- a/Settings/Profile.lua
+++ b/Settings/Profile.lua
@@ -1157,6 +1157,10 @@ P.quest = {
 				enable = false,
 				sound = "WT Accept",
 			},
+			objectiveProgress = {
+				enable = false,
+				sound = "WT Simple",
+			},
 			partialComplete = {
 				enable = false,
 				sound = "WT Clear",


### PR DESCRIPTION
## Description

This PR introduces a dedicated **sound effect option for Quest Objective Progress**.

Previously, sound effects were only played for full quest completion or overall quest updates. This change adds the necessary configuration and playback logic to play a distinct sound whenever a single quest objective progresses (e.g., meeting kill count, collecting an item).

**Key Changes:**
* Added `objectiveProgress` sound configuration group to the options panel.
* Implemented `QUEST_STATUS.OBJECTIVE_UPDATE` handling in the sound playback function.
* Updated default profile settings to include the new sound option.

## Related Issue(s)

## Screenshots