### PR TITLE
fix: check if values are secret before using them

### DIFF
--- a/Core/KeystoneInfo.lua
+++ b/Core/KeystoneInfo.lua
@@ -130,7 +130,7 @@ end)
 ---@param unit UnitToken
 ---@return KeystoneInfoData?
 function KI:UnitData(unit)
-	if not unit or not UnitIsPlayer(unit) then
+	if not unit or E:IsSecretValue(unit) or not UnitIsPlayer(unit) then
 		return
 	end
 

--- a/Modules/Announcement/ResetInstance.lua
+++ b/Modules/Announcement/ResetInstance.lua
@@ -66,7 +66,7 @@ function A:ResetInstanceUpdateIgnoreState(event, text)
 			end
 		end)
 	elseif event == "CHAT_MSG_SYSTEM" then
-		if text and (text == ERR_RAID_CONVERTED_TO_PARTY or text == ERR_PARTY_CONVERTED_TO_RAID) then
+		if text and (not E:IsSecretValue(text)) and (text == ERR_RAID_CONVERTED_TO_PARTY or text == ERR_PARTY_CONVERTED_TO_RAID) then
 			ignoreCondition.justChangedGroupType = t
 			E:Delay(1, function()
 				if ignoreCondition.justChangedGroupType == t then
@@ -80,7 +80,7 @@ end
 
 function A:ResetInstance(text)
 	local config = self.db.resetInstance
-	if not config or not config.enable then
+	if not config or not config.enable or E:IsSecretValue(text) then
 		return
 	end
 

--- a/Modules/Misc/GameBar.lua
+++ b/Modules/Misc/GameBar.lua
@@ -528,7 +528,7 @@ local ButtonTypes = {
 		},
 		eventHandler = function(button, event, message)
 			if event == "CHAT_MSG_SYSTEM" then
-				if not (strfind(message, friendOnline) or strfind(message, friendOffline)) then
+				if E:IsSecretValue(message) or not (strfind(message, friendOnline) or strfind(message, friendOffline)) then
 					return
 				end
 			end

--- a/Modules/Skins/Core.lua
+++ b/Modules/Skins/Core.lua
@@ -207,6 +207,10 @@ do
 			return
 		end
 
+		if E:IsSecretValue(r) or E:IsSecretValue(g) or E:IsSecretValue(b) then
+			return
+		end
+
 		if r == E.db.general.bordercolor.r and g == E.db.general.bordercolor.g and b == E.db.general.bordercolor.b then
 			S:UpdateShadowColor(shadow)
 		else

--- a/Modules/Skins/TextureString.lua
+++ b/Modules/Skins/TextureString.lua
@@ -38,6 +38,7 @@ local function cacheTextureString(iconData, formattedString)
 end
 
 function S:StyleTextureString(text)
+	if E:IsSecretValue(text) then return text end
 	if not text or not strfind(text, "|T.+|t") then
 		return text
 	end

--- a/Modules/Social/ChatText.lua
+++ b/Modules/Social/ChatText.lua
@@ -1008,7 +1008,7 @@ function CT:CheckLFGRoles()
 end
 
 function CT:HandleName(nameString)
-	if not nameString or nameString == "" then
+	if not nameString or E:IsSecretValue(nameString) or nameString == "" then
 		return nameString
 	end
 
@@ -2269,7 +2269,7 @@ function CT:ElvUIChat_AchievementMessageHandler(event, frame, achievementMessage
 end
 
 function CT:ElvUIChat_GuildMemberStatusMessageHandler(frame, msg)
-	if not frame or not msg then
+	if not frame or not msg or E:IsSecretValue(msg) then
 		return
 	end
 

--- a/Modules/Tooltips/Core.lua
+++ b/Modules/Tooltips/Core.lua
@@ -123,7 +123,7 @@ function T:InspectInfo(tt, data, triedTimes)
 		end
 	end
 
-	if not unit or not data or not data.guid then
+	if not unit or not data or not data.guid or E:IsSecretValue(unit) then
 		return
 	end
 

--- a/Modules/Tooltips/Icons.lua
+++ b/Modules/Tooltips/Icons.lua
@@ -112,7 +112,7 @@ local function setTooltipIcon(tt, data, type)
 	for i = 1, 3 do
 		local row = _G[tt:GetName() .. "TextLeft" .. i]
 		local existingText = row and row:GetText()
-		if existingText and strfind(existingText, title, 1, true) then
+		if existingText and (not E:IsSecretValue(existingText)) and strfind(existingText, title, 1, true) then
 			if iconString and existingText and not strfind(existingText, "^|T") then
 				row:SetText(iconString .. " " .. existingText)
 			end

--- a/Modules/Tooltips/ObjectiveProgress.lua
+++ b/Modules/Tooltips/ObjectiveProgress.lua
@@ -31,7 +31,7 @@ local function addObjectiveProgress(tt, data)
 		return
 	end
 
-	local npcID = data and data.guid and select(6, strsplit("-", data.guid))
+	local npcID = data and data.guid and not E:IsSecretValue(data.guid) and select(6, strsplit("-", data.guid))
 
 	if not npcID or npcID == "" then
 		return


### PR DESCRIPTION
## Description

In instances some values are secret.
These changes check if some of the values used are secret, and skips logic if they are.
Ran some instances and fixed all errors that popped up.

## Related Issue(s)

- Fixes https://github.com/wind-addons/ElvUI_WindTools/issues/582

## Screenshots

<!-- Add screenshots of the changes if applicable. -->