### PR TITLE
Fix: Prevent string conversion crash on secret values in Social Modules

### DIFF
--- a/Modules/Social/ChatLink.lua
+++ b/Modules/Social/ChatLink.lua
@@ -286,9 +286,6 @@ local function AddCurrencyInfo(link)
 end
 
 function CL:Filter(event, msg, ...)
-	-- WoW Midnight introduces secret string values for some chat payloads.
-	-- String operations (gsub, strlower, format, etc) crash if applied to them.
-	-- Guard with E:NotSecretValue to safely skip protected payloads.
 	if CL.db.enable and E:NotSecretValue(msg) then
 		msg = gsub(msg, "(|cff71d5ff|Hconduit:%d+:.-|h.-|h|r)", AddConduitIcon)
 		msg = gsub(msg, "(|cffa335ee|Hkeystone:%d+:.-|h.-|h|r)", AddKeystoneIcon)

--- a/Modules/Social/ChatText.lua
+++ b/Modules/Social/ChatText.lua
@@ -905,26 +905,19 @@ function CT:ChatFrame_MessageEventHandler(frame, event, arg1, arg2, arg3, arg4, 
 		end
 
 		if frame.privateMessageList then
-			-- HACK to put certain system messages into dedicated whisper windows
-			-- WoW Midnight introduces secret string values for some chat payloads.
-			-- String operations (gsub, strlower, format, etc) crash if applied to them.
-			-- Guard with E:NotSecretValue to safely skip protected payloads.
-			if chatGroup == 'SYSTEM' then
-				local matchFound = false
-				if E:NotSecretValue(arg1) then
-					local message = strlower(arg1)
-					for playerName in pairs(frame.privateMessageList) do
-						local playerNotFoundMsg = strlower(format(_G.ERR_CHAT_PLAYER_NOT_FOUND_S, playerName))
-						local charOnlineMsg = strlower(format(_G.ERR_FRIEND_ONLINE_SS, playerName, playerName))
-						local charOfflineMsg = strlower(format(_G.ERR_FRIEND_OFFLINE_S, playerName))
-						if message == playerNotFoundMsg or message == charOnlineMsg or message == charOfflineMsg then
-							matchFound = true
-							break
-						end
+			if chatGroup == 'SYSTEM' then -- HACK to put certain system messages into dedicated whisper windows
+				local found, msg = false, strlower(arg1)
+				for playerName in pairs(frame.privateMessageList) do
+					local playerNotFoundMsg = strlower(format(_G.ERR_CHAT_PLAYER_NOT_FOUND_S, playerName))
+					local charOnlineMsg = strlower(format(_G.ERR_FRIEND_ONLINE_SS, playerName, playerName))
+					local charOfflineMsg = strlower(format(_G.ERR_FRIEND_OFFLINE_S, playerName))
+					if msg == playerNotFoundMsg or msg == charOnlineMsg or msg == charOfflineMsg then
+						found = true
+						break
 					end
 				end
 
-				if not matchFound then
+				if not found then
 					return true
 				end
 			elseif not isProtected and (chatGroup == 'BN_INLINE_TOAST_ALERT' or chatGroup == 'BN_WHISPER_PLAYER_OFFLINE') then

--- a/Modules/Social/Emote.lua
+++ b/Modules/Social/Emote.lua
@@ -110,9 +110,6 @@ local function ReplaceEmote(value)
 end
 
 local function EmoteFilter(_, _, msg, ...)
-	-- WoW Midnight introduces secret string values for some chat payloads.
-	-- String operations (gsub, strlower, format, etc) crash if applied to them.
-	-- Guard with E:NotSecretValue to safely skip protected payloads.
 	if CE.db.enable and E:NotSecretValue(msg) then
 		msg = gsub(msg, "%{.-%}", ReplaceEmote)
 	end


### PR DESCRIPTION
## Description

Fixes a crash introduced in **WoW Midnight (Interface 120001+)** when handling *secret string values* in chat payloads.

Certain system and chat messages are now delivered as protected values. Attempting to manipulate these values using standard Lua string operations (`strlower`, `gsub`, `format`, etc.) results in the runtime error:

`attempt to perform string conversion on a secret string value`

This PR introduces defensive guards using ElvUI's `E:NotSecretValue()` utility before performing string transformations on `CHAT_MSG_*` payloads.

### Scope

The vulnerable pattern was found in multiple Social modules and has been patched in:

- **Modules/Social/ChatText.lua**  
  Guarded `strlower(arg1)` used when inspecting `CHAT_MSG_SYSTEM` messages.

- **Modules/Social/Emote.lua**  
  Guarded `gsub(msg, ...)` inside `EmoteFilter`.

- **Modules/Social/ChatLink.lua**  
  Guarded sequential `gsub(msg, ...)` operations inside `CL:Filter`.

### Behavior

If the chat payload is a regular string, WindTools continues applying its enhancements (whisper routing, emote replacement, link formatting).

If the payload is a **secret value**, WindTools skips inspection and allows the message to pass through the normal Blizzard/ElvUI chat pipeline.

This prevents crashes while preserving existing functionality for normal messages.

### Manual Validation

- Verified `CHAT_MSG_SYSTEM` messages no longer trigger Lua errors.
- Confirmed `{emote}` replacements still work in chat.
- Confirmed item/achievement/spell links retain their injected metadata.

*Note: This PR focuses only on Social modules that manipulate chat payloads.*

## Related Issue(s)

(No related issue currently tracks this Midnight crash.)

## Screenshots

N/A – logic fix only.